### PR TITLE
Temporarily disabling celery beat and also updating reqs.txt

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -42,7 +42,8 @@ def make_celery(app_name=__name__):
 
 celery = make_celery()
 celery.conf['broker_transport_options']=broker_transport_options
-db = SQLAlchemy()
+#db = SQLAlchemy() # altering this to use the engine_options parameter to set pool_recycle and pool_pre_ping to ensure connection 
+db = SQLAlchemy(engine_options={"pool_recycle": 3600, "pool_pre_ping": True})
 migrate = Migrate()
 login = LoginManager()
 login.login_view = 'auth.login'

--- a/app/celery_utils.py
+++ b/app/celery_utils.py
@@ -1,12 +1,12 @@
 from celery.schedules import crontab
 
 def init_celery(celery, app):
-
     celery.conf.update(app.config)
 
     celery.conf.update(
         enable_utc = False,
-        timezone = 'America/New_York'
+        timezone = 'America/New_York', 
+        broker_pool_limit = None, 
     )
 
     celery.conf.beat_schedule = {"run-me-on_wednesday": {

--- a/app/database/modifications.py
+++ b/app/database/modifications.py
@@ -4,6 +4,7 @@ from app.database import protein as protein_mod
 # from sqlalchemy.types import db.Integer, db.String, CHAR, Float, Enum, DateTime
 # from sqlalchemy.orm import db.relationship
 from sqlalchemy.sql.expression import and_, or_
+from sqlalchemy import Enum
 from app import db
 from functools import reduce
 import enum
@@ -18,20 +19,20 @@ class PTMkeyword(db.Model):
     PTM_id = db.Column(db.Integer, db.ForeignKey('PTM.id'))
     keyword = db.Column(db.String(100))
 
-class PosiitionEnum(enum.Enum):
-    anywhere = 'anywhere'
-    c_terminal = 'c-terminal'
-    n_terminal = 'n-terminal'
-    core = 'core'
-    none = None  # Add this line
+#class PosiitionEnum(enum.Enum):
+  #  anywhere = 'anywhere'
+  #  c_terminal = 'c-terminal'
+  #  n_terminal = 'n-terminal'
+  #  core = 'core'
+  #  none = None  # Add this line
 
 class PTM(db.Model):
     __tablename__ = 'PTM'
     
     id = db.Column(db.Integer, autoincrement=True, primary_key=True)
     name = db.Column(db.String(100), unique=True)
-    
-    position = db.Column(db.Enum(PosiitionEnum), nullable=True)  # Make sure the column is nullable
+    ## testing different ways to define the enum
+    position = db.Column(Enum('anywhere', 'c-terminal', 'n-terminal', 'core', name='positionenum'), nullable=True)
     
     accession = db.Column(db.String(10))
     target = db.Column(db.String(0))

--- a/app/static/js/protein_viewer/viewer.js
+++ b/app/static/js/protein_viewer/viewer.js
@@ -193,7 +193,7 @@ function StructureViewer(protein_data) {
     this.axis = d3.scaleLinear().domain([0, protein_data.seq.length]).range([0, this.width]);
     
     this.domain_colors = d3.scaleOrdinal(d3.schemeSet2); //was schemeCategory20
-    this.region_colors =  d3.scaleOrdinal(d3.schemeCategory10); //was schemeCategory20b
+    this.region_colors =  d3.scaleOrdinal(d3.schemePaired); //was schemeCategory20b
     this.residue_colors = create_amino_acid_colors();
 
     var macro_residues = this.protein_data.seq.length <= this.show_residues_size_limit;


### PR DESCRIPTION
Disabled celery beat since it is causing failures and also updated celery + its dependencies as the prior version (5.2.7) had documented issues with the current version of SQS where queues in celery ceased to work after any network failure. Tested this change in local docker instance and also in test app. 